### PR TITLE
feat: implement Arc with RwLock for interior mutability to be thread-safe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.22.0
+          - 1.49.0
           - stable
     steps:
     - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: rctree
+name: arctree
 
 on: [push, pull_request]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,13 @@ authors = [
     "Yevhenii Reizner <razrfalcon@gmail.com>"
 ]
 license = "MIT"
-description = "A 'DOM-like' tree implemented using reference counting"
+description = "A 'DOM-like' tree implemented using atomic reference counting"
 repository = "https://github.com/RazrFalcon/rctree"
 documentation = "https://docs.rs/rctree/"
 readme = "README.md"
+
+[dependencies]
+parking_lot = "0.12.1"
+
+[dev-dependencies]
+ntest = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
-name = "rctree"
+name = "arctree"
 version = "0.6.0"
 authors = [
     "Simon Sapin <simon.sapin@exyr.org>",
-    "Yevhenii Reizner <razrfalcon@gmail.com>"
+    "Yevhenii Reizner <razrfalcon@gmail.com>",
+    "Youn Mélois <youn@melois.dev>",
 ]
 license = "MIT"
 description = "A 'DOM-like' tree implemented using atomic reference counting"
-repository = "https://github.com/RazrFalcon/rctree"
-documentation = "https://docs.rs/rctree/"
+repository = "https://github.com/sehnryr/arctree"
+documentation = "https://docs.rs/arctree/"
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "arctree"
 version = "0.1.0"
+edition = "2018"
 authors = [
     "Simon Sapin <simon.sapin@exyr.org>",
     "Yevhenii Reizner <razrfalcon@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arctree"
-version = "0.6.0"
+version = "0.1.0"
 authors = [
     "Simon Sapin <simon.sapin@exyr.org>",
     "Yevhenii Reizner <razrfalcon@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ readme = "README.md"
 
 [dependencies]
 parking_lot = "0.12.1"
-
-[dev-dependencies]
-ntest = "0.9.2"

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) 2018 Simon Sapin
 Copyright (c) 2018 Yevhenii Reizner
+Copyright (c) 2024 Youn Mélois
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/sehnryr/arctree/workflows/arctree/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/arctree.svg)](https://crates.io/crates/arctree)
 [![Documentation](https://docs.rs/arctree/badge.svg)](https://docs.rs/arctree)
-[![Rust 1.22+](https://img.shields.io/badge/rust-1.22+-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.49.0](https://img.shields.io/badge/rust-1.49.0-orange.svg)](https://releases.rs/docs/1.49.0/)
 ![](https://img.shields.io/badge/unsafe-forbidden-brightgreen.svg)
 
 *arctree* is a "DOM-like" tree implemented using atomic reference counting.
@@ -65,6 +65,10 @@ Disadvantages:
   requires incrementing and decrementing reference counts,
   which causes run-time overhead.
 * Nodes are allocated individually, which may cause memory fragmentation and hurt performance.
+
+## Minimum Supported Rust Version (MSRV)
+
+The current MSRV is 1.49.0 due to the `parking_lot` dependency.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# rctree
-![Build Status](https://github.com/RazrFalcon/rctree/workflows/rctree/badge.svg)
-[![Crates.io](https://img.shields.io/crates/v/rctree.svg)](https://crates.io/crates/rctree)
-[![Documentation](https://docs.rs/rctree/badge.svg)](https://docs.rs/rctree)
+# arctree
+![Build Status](https://github.com/sehnryr/arctree/workflows/arctree/badge.svg)
+[![Crates.io](https://img.shields.io/crates/v/arctree.svg)](https://crates.io/crates/arctree)
+[![Documentation](https://docs.rs/arctree/badge.svg)](https://docs.rs/arctree)
 [![Rust 1.22+](https://img.shields.io/badge/rust-1.22+-orange.svg)](https://www.rust-lang.org)
 ![](https://img.shields.io/badge/unsafe-forbidden-brightgreen.svg)
 
-*rctree* is a "DOM-like" tree implemented using atomic reference counting.
+*arctree* is a "DOM-like" tree implemented using atomic reference counting.
 
 ### Origin
 
-This is a fork of the [rust-forest](https://github.com/SimonSapin/rust-forest) rctree.
+This is a fork of [rctree](https://github.com/RazrFalcon/rctree).
 
 ### Details
 
@@ -68,4 +68,4 @@ Disadvantages:
 
 ### License
 
-*rctree* is licensed under the **MIT**.
+*arctree* is licensed under the **MIT License**.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Rust 1.22+](https://img.shields.io/badge/rust-1.22+-orange.svg)](https://www.rust-lang.org)
 ![](https://img.shields.io/badge/unsafe-forbidden-brightgreen.svg)
 
-*rctree* is a "DOM-like" tree implemented using reference counting.
+*rctree* is a "DOM-like" tree implemented using atomic reference counting.
 
 ### Origin
 
@@ -34,7 +34,7 @@ That is:
 * The tree is mutable:
   nodes (with their sub-trees) can be inserted or removed anywhere in the tree.
 
-The lifetime of nodes is managed through *reference counting*.
+The lifetime of nodes is managed through *atomic reference counting*.
 To avoid reference cycles which would cause memory leaks, the tree is *asymmetric*:
 each node holds optional *strong references* to its next sibling and first child,
 but only optional *weak references* to its parent, previous sibling, and last child.
@@ -51,7 +51,8 @@ Weak references to destroyed nodes are treated as if they were not set at all.
 (E.g. a node can become a root when its parent is destroyed.)
 
 Since nodes are *aliased* (have multiple references to them),
-[`RefCell`](http://doc.rust-lang.org/std/cell/index.html) is used for interior mutability.
+[`RwLock`](https://docs.rs/parking_lot/0.12.1/parking_lot/rwlock/type.RwLock.html)
+is used for interior mutability.
 
 Advantages:
 
@@ -60,7 +61,6 @@ Advantages:
 
 Disadvantages:
 
-* The tree can only be accessed from the thread is was created in.
 * Any tree manipulation, including read-only traversals,
   requires incrementing and decrementing reference counts,
   which causes run-time overhead.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 *arctree* is a "DOM-like" tree implemented using atomic reference counting.
 
-### Origin
+## Origin
 
 This is a fork of [rctree](https://github.com/RazrFalcon/rctree).
 
-### Details
+## Details
 
 "DOM-like" here means that data structures can be used to represent
 the parsed content of an HTML or XML document,
@@ -66,6 +66,6 @@ Disadvantages:
   which causes run-time overhead.
 * Nodes are allocated individually, which may cause memory fragmentation and hurt performance.
 
-### License
+## License
 
 *arctree* is licensed under the **MIT License**.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,6 @@ Disadvantages:
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
-extern crate parking_lot;
-
 use std::fmt;
 use std::sync::{Arc, Weak};
 
@@ -107,13 +105,13 @@ impl<T> PartialEq for Node<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for Node<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&*self.read(), f)
     }
 }
 
 impl<T: fmt::Display> fmt::Display for Node<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.read(), f)
     }
 }
@@ -451,7 +449,7 @@ impl<T> Clone for WeakNode<T> {
 }
 
 impl<T: fmt::Debug> fmt::Debug for WeakNode<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("(WeakNode)")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 /*!
 
-*rctree* is a "DOM-like" tree implemented using atomic reference counting.
+*arctree* is a "DOM-like" tree implemented using atomic reference counting.
 
 "DOM-like" here means that data structures can be used to represent
 the parsed content of an HTML or XML document,
@@ -57,7 +57,7 @@ Disadvantages:
 
 */
 
-#![doc(html_root_url = "https://docs.rs/rctree/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/arctree")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,3 @@
-extern crate arctree;
-
 use std::fmt;
 use std::sync::mpsc::channel;
 use std::thread;
@@ -87,7 +85,7 @@ fn it_works() {
 struct TreePrinter<T>(Node<T>);
 
 impl<T: fmt::Debug> fmt::Debug for TreePrinter<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{:?}", self.0.read()).unwrap();
         iter_children(&self.0, 1, f);
 
@@ -95,7 +93,7 @@ impl<T: fmt::Debug> fmt::Debug for TreePrinter<T> {
     }
 }
 
-fn iter_children<T: fmt::Debug>(parent: &Node<T>, depth: usize, f: &mut fmt::Formatter) {
+fn iter_children<T: fmt::Debug>(parent: &Node<T>, depth: usize, f: &mut fmt::Formatter<'_>) {
     for child in parent.children() {
         for _ in 0..depth {
             write!(f, "    ").unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,8 @@
 extern crate ntest;
-extern crate rctree;
+extern crate arctree;
 
 use ntest::timeout;
-use rctree::{Node, NodeEdge};
+use arctree::{Node, NodeEdge};
 
 use std::fmt;
 


### PR DESCRIPTION
Rebrand to `arctree` which will be its own crate

Implemented `Arc` with `RwLock` for interior mutability to be thread-safe.

Had to import [`parking_lot`](https://crates.io/crates/parking_lot) for [`MappedRwLockReadGuard`](https://docs.rs/parking_lot/0.12.1/parking_lot/type.MappedRwLockReadGuard.html) and [`MappedRwLockWriteGuard`](https://docs.rs/parking_lot/0.12.1/parking_lot/type.MappedRwLockWriteGuard.html) to make only data member visible when "borrowing":

`borrow` and `borrow_mut` functions have been changed to `read` and `write` respectively since it is not possible to borrow a reference to the internal data member out of RwLock guards. But the migration between the two should just be renaming `borrow` to `read` and `borrow_mut` to `write`.